### PR TITLE
Improve task placement strategy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,14 +19,15 @@ resource "aws_ecs_service" "service" {
     type  = "spread"
     field = "attribute:ecs.availability-zone"
   }
-
-  ordered_placement_strategy {
-    type  = "binpack"
-    field = "cpu"
-  }
   
+  ordered_placement_strategy {
+    type  = lower(var.distinct_task_placement) == "true" ? "binpack" : "spread"
+    field = lower(var.distinct_task_placement) == "true" ? "cpu" : "instanceId"
+  }
+
   placement_constraints {
-    type = "distinctInstance"
+    type = lower(var.distinct_task_placement) == "true" ? "distinctInstance" : "memberOf"
+    expression = lower(var.distinct_task_placement) == "true" ? "" : "agentConnected == true"
   }
 
   lifecycle {
@@ -48,14 +49,15 @@ resource "aws_ecs_service" "service_no_loadbalancer" {
     type  = "spread"
     field = "attribute:ecs.availability-zone"
   }
-
-  ordered_placement_strategy {
-    type  = "binpack"
-    field = "cpu"
-  }
   
+  ordered_placement_strategy {
+    type  = lower(var.distinct_task_placement) == "true" ? "binpack" : "spread"
+    field = lower(var.distinct_task_placement) == "true" ? "cpu" : "instanceId"
+  }
+
   placement_constraints {
-    type = "distinctInstance"
+    type = lower(var.distinct_task_placement) == "true" ? "distinctInstance" : "memberOf"
+    expression = lower(var.distinct_task_placement) == "true" ? "" : "agentConnected == true"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -21,13 +21,13 @@ resource "aws_ecs_service" "service" {
   }
   
   ordered_placement_strategy {
-    type  = lower(var.distinct_task_placement) == "true" ? "binpack" : "spread"
-    field = lower(var.distinct_task_placement) == "true" ? "cpu" : "instanceId"
+    type  = lower(var.pack_and_distinct) == "true" ? "binpack" : "spread"
+    field = lower(var.pack_and_distinct) == "true" ? "cpu" : "instanceId"
   }
 
   placement_constraints {
-    type = lower(var.distinct_task_placement) == "true" ? "distinctInstance" : "memberOf"
-    expression = lower(var.distinct_task_placement) == "true" ? "" : "agentConnected == true"
+    type = lower(var.pack_and_distinct) == "true" ? "distinctInstance" : "memberOf"
+    expression = lower(var.pack_and_distinct) == "true" ? "" : "agentConnected == true"
   }
 
   lifecycle {
@@ -51,13 +51,13 @@ resource "aws_ecs_service" "service_no_loadbalancer" {
   }
   
   ordered_placement_strategy {
-    type  = lower(var.distinct_task_placement) == "true" ? "binpack" : "spread"
-    field = lower(var.distinct_task_placement) == "true" ? "cpu" : "instanceId"
+    type  = lower(var.pack_and_distinct) == "true" ? "binpack" : "spread"
+    field = lower(var.pack_and_distinct) == "true" ? "cpu" : "instanceId"
   }
 
   placement_constraints {
-    type = lower(var.distinct_task_placement) == "true" ? "distinctInstance" : "memberOf"
-    expression = lower(var.distinct_task_placement) == "true" ? "" : "agentConnected == true"
+    type = lower(var.pack_and_distinct) == "true" ? "distinctInstance" : "memberOf"
+    expression = lower(var.pack_and_distinct) == "true" ? "" : "agentConnected == true"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -21,8 +21,12 @@ resource "aws_ecs_service" "service" {
   }
 
   ordered_placement_strategy {
-    type  = "spread"
-    field = "instanceId"
+    type  = "binpack"
+    field = "cpu"
+  }
+  
+  placement_constraints {
+    type = "distinctInstance"
   }
 
   lifecycle {
@@ -46,8 +50,12 @@ resource "aws_ecs_service" "service_no_loadbalancer" {
   }
 
   ordered_placement_strategy {
-    type  = "spread"
-    field = "instanceId"
+    type  = "binpack"
+    field = "cpu"
+  }
+  
+  placement_constraints {
+    type = "distinctInstance"
   }
 }
 

--- a/test/files/create_ecs_service.json
+++ b/test/files/create_ecs_service.json
@@ -21,6 +21,7 @@
           "deployment_minimum_healthy_percent": 100,
           "desired_count": 3,
           "enable_ecs_managed_tags": false,
+          "force_new_deployment": null,
           "health_check_grace_period_seconds": null,
           "load_balancer": [
             {
@@ -42,13 +43,20 @@
               "type": "spread"
             }
           ],
-          "placement_constraints": [],
+          "placement_constraints": [
+            {
+              "expression": "agentConnected == true",
+              "type": "memberOf"
+            }
+          ],
           "propagate_tags": null,
           "scheduling_strategy": "REPLICA",
           "service_registries": [],
           "tags": null,
-          "task_definition": "test-taskdef"
-        },
+          "task_definition": "test-taskdef",
+          "timeouts": null,
+          "wait_for_steady_state": false
+      },
         "after_unknown": {
           "capacity_provider_strategy": [],
           "deployment_controller": [],
@@ -63,8 +71,7 @@
             {},
             {}
           ],
-          "placement_constraints": [],
-          "placement_strategy": true,
+          "placement_constraints": [{}],
           "platform_version": true,
           "service_registries": []
         }

--- a/test/files/create_service_with_long_name.json
+++ b/test/files/create_service_with_long_name.json
@@ -21,6 +21,7 @@
           "deployment_minimum_healthy_percent": 100,
           "desired_count": 3,
           "enable_ecs_managed_tags": false,
+          "force_new_deployment": null,
           "health_check_grace_period_seconds": null,
           "load_balancer": [
             {
@@ -42,12 +43,19 @@
               "type": "spread"
             }
           ],
-          "placement_constraints": [],
+          "placement_constraints": [
+            {
+              "expression": "agentConnected == true",
+              "type": "memberOf"
+            }
+          ],
           "propagate_tags": null,
           "scheduling_strategy": "REPLICA",
           "service_registries": [],
           "tags": null,
-          "task_definition": "test-taskdef"
+          "task_definition": "test-taskdef",
+          "timeouts": null,
+          "wait_for_steady_state": false
         },
         "after_unknown": {
           "capacity_provider_strategy": [],
@@ -63,8 +71,7 @@
             {},
             {}
           ],
-          "placement_constraints": [],
-          "placement_strategy": true,
+          "placement_constraints": [{}],
           "platform_version": true,
           "service_registries": []
         }

--- a/test/files/create_service_with_pack_and_distinct_task_placement.json
+++ b/test/files/create_service_with_pack_and_distinct_task_placement.json
@@ -1,0 +1,135 @@
+{
+  "resource_changes": [
+    {
+      "address": "module.service_with_pack_and_distinct_task_placement.aws_ecs_service.service[0]",
+      "module_address": "module.service_with_pack_and_distinct_task_placement",
+      "mode": "managed",
+      "type": "aws_ecs_service",
+      "name": "service",
+      "index": 0,
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "capacity_provider_strategy": [],
+          "cluster": "default",
+          "deployment_controller": [],
+          "deployment_maximum_percent": 200,
+          "deployment_minimum_healthy_percent": 100,
+          "desired_count": 3,
+          "enable_ecs_managed_tags": false,
+          "force_new_deployment": null,
+          "health_check_grace_period_seconds": null,
+          "load_balancer": [
+            {
+              "container_name": "app",
+              "container_port": 8000,
+              "elb_name": "",
+              "target_group_arn": "arn:aws:elasticloadbalancing:eu-west-1:123456789012:targetgroup/test-service/1234abcd123456ba1"
+            }
+          ],
+          "name": "test-service",
+          "network_configuration": [],
+          "ordered_placement_strategy": [
+            {
+              "field": "attribute:ecs.availability-zone",
+              "type": "spread"
+            },
+            {
+              "field": "cpu",
+              "type": "binpack"
+            }
+          ],
+          "placement_constraints": [
+            {
+              "expression": "",
+              "type": "distinctInstance"
+            }
+          ],
+          "propagate_tags": null,
+          "scheduling_strategy": "REPLICA",
+          "service_registries": [],
+          "tags": null,
+          "task_definition": "test-taskdef",
+          "timeouts": null,
+          "wait_for_steady_state": false
+      },
+        "after_unknown": {
+          "capacity_provider_strategy": [],
+          "deployment_controller": [],
+          "iam_role": true,
+          "id": true,
+          "launch_type": true,
+          "load_balancer": [
+            {}
+          ],
+          "network_configuration": [],
+          "ordered_placement_strategy": [
+            {},
+            {}
+          ],
+          "placement_constraints": [{}],
+          "platform_version": true,
+          "service_registries": []
+        }
+      }
+    },
+    {
+      "address": "module.service_with_pack_and_distinct_task_placement.aws_iam_role.role",
+      "module_address": "module.service_with_pack_and_distinct_task_placement",
+      "mode": "managed",
+      "type": "aws_iam_role",
+      "name": "role",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "assume_role_policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": { \"Service\": \"ecs.amazonaws.com\" },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+          "description": null,
+          "force_detach_policies": false,
+          "max_session_duration": 3600,
+          "name_prefix": "test-service",
+          "path": "/",
+          "permissions_boundary": null,
+          "tags": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "create_date": true,
+          "id": true,
+          "name": true,
+          "unique_id": true
+        }
+      }
+    },
+    {
+      "address": "module.service_with_pack_and_distinct_task_placement.aws_iam_role_policy.policy",
+      "module_address": "module.service_with_pack_and_distinct_task_placement",
+      "mode": "managed",
+      "type": "aws_iam_role_policy",
+      "name": "policy",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "name_prefix": "test-service",
+          "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"ec2:AuthorizeSecurityGroupIngress\",\n        \"ec2:Describe*\",\n        \"elasticloadbalancing:DeregisterInstancesFromLoadBalancer\",\n        \"elasticloadbalancing:DeregisterTargets\",\n        \"elasticloadbalancing:Describe*\",\n        \"elasticloadbalancing:RegisterInstancesWithLoadBalancer\",\n        \"elasticloadbalancing:RegisterTargets\"\n      ],\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+        },
+        "after_unknown": {
+          "id": true,
+          "name": true,
+          "role": true
+        }
+      }
+    }
+  ]
+}

--- a/test/files/min_and_max_percent.json
+++ b/test/files/min_and_max_percent.json
@@ -21,6 +21,7 @@
           "deployment_minimum_healthy_percent": 0,
           "desired_count": 3,
           "enable_ecs_managed_tags": false,
+          "force_new_deployment": null,
           "health_check_grace_period_seconds": null,
           "load_balancer": [
             {
@@ -42,12 +43,19 @@
               "type": "spread"
             }
           ],
-          "placement_constraints": [],
+          "placement_constraints": [
+            {
+              "expression": "agentConnected == true",
+              "type": "memberOf"
+            }
+          ],
           "propagate_tags": null,
           "scheduling_strategy": "REPLICA",
           "service_registries": [],
           "tags": null,
-          "task_definition": "test-taskdef"
+          "task_definition": "test-taskdef",
+          "timeouts": null,
+          "wait_for_steady_state": false
         },
         "after_unknown": {
           "capacity_provider_strategy": [],
@@ -63,8 +71,7 @@
             {},
             {}
           ],
-          "placement_constraints": [],
-          "placement_strategy": true,
+          "placement_constraints": [{}],
           "platform_version": true,
           "service_registries": []
         }

--- a/test/files/no_target_group.json
+++ b/test/files/no_target_group.json
@@ -21,6 +21,7 @@
           "deployment_minimum_healthy_percent": 100,
           "desired_count": 3,
           "enable_ecs_managed_tags": false,
+          "force_new_deployment": null,
           "health_check_grace_period_seconds": null,
           "load_balancer": [],
           "name": "test-service",
@@ -35,12 +36,19 @@
               "type": "spread"
             }
           ],
-          "placement_constraints": [],
+          "placement_constraints": [
+            {
+              "expression": "agentConnected == true",
+              "type": "memberOf"
+            }
+          ],
           "propagate_tags": null,
           "scheduling_strategy": "REPLICA",
           "service_registries": [],
           "tags": null,
-          "task_definition": "test-taskdef"
+          "task_definition": "test-taskdef",
+          "timeouts": null,
+          "wait_for_steady_state": false
         },
         "after_unknown": {
           "capacity_provider_strategy": [],
@@ -54,8 +62,7 @@
             {},
             {}
           ],
-          "placement_constraints": [],
-          "placement_strategy": true,
+          "placement_constraints": [{}],
           "platform_version": true,
           "service_registries": []
         }

--- a/test/files/no_target_group_pack_and_distinct_task_placement.json
+++ b/test/files/no_target_group_pack_and_distinct_task_placement.json
@@ -1,0 +1,126 @@
+{
+  "resource_changes": [
+    {
+      "address": "module.no_target_group_pack_and_distinct_task_placement.aws_ecs_service.service_no_loadbalancer[0]",
+      "module_address": "module.no_target_group_pack_and_distinct_task_placement",
+      "mode": "managed",
+      "type": "aws_ecs_service",
+      "name": "service_no_loadbalancer",
+      "index": 0,
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "capacity_provider_strategy": [],
+          "cluster": "default",
+          "deployment_controller": [],
+          "deployment_maximum_percent": 200,
+          "deployment_minimum_healthy_percent": 100,
+          "desired_count": 3,
+          "enable_ecs_managed_tags": false,
+          "force_new_deployment": null,
+          "health_check_grace_period_seconds": null,
+          "load_balancer": [],
+          "name": "test-service",
+          "network_configuration": [],
+          "ordered_placement_strategy": [
+            {
+              "field": "attribute:ecs.availability-zone",
+              "type": "spread"
+            },
+            {
+              "field": "cpu",
+              "type": "binpack"
+            }
+          ],
+          "placement_constraints": [
+            {
+              "expression": "",
+              "type": "distinctInstance"
+            }
+          ],
+          "propagate_tags": null,
+          "scheduling_strategy": "REPLICA",
+          "service_registries": [],
+          "tags": null,
+          "task_definition": "test-taskdef",
+          "timeouts": null,
+          "wait_for_steady_state": false
+        },
+        "after_unknown": {
+          "capacity_provider_strategy": [],
+          "deployment_controller": [],
+          "iam_role": true,
+          "id": true,
+          "launch_type": true,
+          "load_balancer": [],
+          "network_configuration": [],
+          "ordered_placement_strategy": [
+            {},
+            {}
+          ],
+          "placement_constraints": [{}],
+          "platform_version": true,
+          "service_registries": []
+        }
+      }
+    },
+    {
+      "address": "module.no_target_group_pack_and_distinct_task_placement.aws_iam_role.role",
+      "module_address": "module.no_target_group_pack_and_distinct_task_placement",
+      "mode": "managed",
+      "type": "aws_iam_role",
+      "name": "role",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "assume_role_policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": { \"Service\": \"ecs.amazonaws.com\" },\n      \"Effect\": \"Allow\"\n    }\n  ]\n}\n",
+          "description": null,
+          "force_detach_policies": false,
+          "max_session_duration": 3600,
+          "name_prefix": "test-service",
+          "path": "/",
+          "permissions_boundary": null,
+          "tags": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "create_date": true,
+          "id": true,
+          "name": true,
+          "unique_id": true
+        }
+      }
+    },
+    {
+      "address": "module.no_target_group_pack_and_distinct_task_placement.aws_iam_role_policy.policy",
+      "module_address": "module.no_target_group_pack_and_distinct_task_placement",
+      "mode": "managed",
+      "type": "aws_iam_role_policy",
+      "name": "policy",
+      "provider_name": "aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "name_prefix": "test-service",
+          "policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"ec2:AuthorizeSecurityGroupIngress\",\n        \"ec2:Describe*\",\n        \"elasticloadbalancing:DeregisterInstancesFromLoadBalancer\",\n        \"elasticloadbalancing:DeregisterTargets\",\n        \"elasticloadbalancing:Describe*\",\n        \"elasticloadbalancing:RegisterInstancesWithLoadBalancer\",\n        \"elasticloadbalancing:RegisterTargets\"\n      ],\n      \"Resource\": \"*\"\n    }\n  ]\n}\n"
+        },
+        "after_unknown": {
+          "id": true,
+          "name": true,
+          "role": true
+        }
+      }
+    }
+  ]
+}

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -47,3 +47,20 @@ module "no_target_group" {
   name            = "test-service"
   task_definition = "test-taskdef"
 }
+
+module "service_with_pack_and_distinct_task_placement" {
+  source = "../.."
+
+  name             = "test-service"
+  task_definition  = "test-taskdef"
+  target_group_arn = "arn:aws:elasticloadbalancing:eu-west-1:123456789012:targetgroup/test-service/1234abcd123456ba1"
+  pack_and_distinct = "true"
+}
+
+module "no_target_group_pack_and_distinct_task_placement" {
+  source = "../.."
+
+  name             = "test-service"
+  task_definition  = "test-taskdef"
+  pack_and_distinct = "true"
+}

--- a/test/test_load_balanced_ecs_service.py
+++ b/test/test_load_balanced_ecs_service.py
@@ -33,6 +33,11 @@ class TestCreateTaskdef(unittest.TestCase):
         with open(f'test/files/{testname}.json', 'r') as f:
             data = json.load(f)
 
+            print('from_json_file******************************')
+            print(data.get('resource_changes'))
+            print('******************************')
+            print('Terraform_output******************************')
+            print(resource_changes)
             assert data.get('resource_changes') == resource_changes
 
     def test_create_ecs_service(self):
@@ -107,3 +112,39 @@ class TestCreateTaskdef(unittest.TestCase):
         assert len(resource_changes) == 3
         self.assert_resource_changes_action(resource_changes, 'create', 3)
         self.assert_resource_changes('no_target_group', resource_changes)
+
+    def test_pack_and_distinct_instance(self):
+        # Given When
+        check_call([
+            'terraform',
+            'plan',
+            '-out=plan.out',
+            '-no-color',
+            '-target=module.service_with_pack_and_distinct_task_placement',
+            'test/infra'
+        ])
+
+        resource_changes = self.get_resource_changes()
+
+        # Then
+        assert len(resource_changes) == 3
+        self.assert_resource_changes_action(resource_changes, 'create', 3)
+        self.assert_resource_changes('create_service_with_pack_and_distinct_task_placement', resource_changes)
+
+    def test_pack_and_distinct_instance(self):
+        # Given When
+        check_call([
+            'terraform',
+            'plan',
+            '-out=plan.out',
+            '-no-color',
+            '-target=module.no_target_group_pack_and_distinct_task_placement',
+            'test/infra'
+        ])
+
+        resource_changes = self.get_resource_changes()
+
+        # Then
+        assert len(resource_changes) == 3
+        self.assert_resource_changes_action(resource_changes, 'create', 3)
+        self.assert_resource_changes('no_target_group_pack_and_distinct_task_placement', resource_changes)

--- a/variables.tf
+++ b/variables.tf
@@ -92,8 +92,8 @@ variable "deployment_maximum_percent" {
   default     = "200"
 }
 
-variable "distinct_task_placement" {
-  description = "Enable distinct instance and binpacking. Enter 'true' for clusters with auto scaling groups. Enter 'false' for clusters with no ASG and instant counts less than or equal to desired tasks"
+variable "pack_and_distinct" {
+  description = "Enable distinct instance and task binpacking for better cluster utilisation. Enter 'true' for clusters with auto scaling groups. Enter 'false' for clusters with no ASG and instant counts less than or equal to desired tasks"
   type = "string"
   default = "false"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -92,3 +92,8 @@ variable "deployment_maximum_percent" {
   default     = "200"
 }
 
+variable "distinct_task_placement" {
+  description = "Enable distinct instance and binpacking. Enter 'true' for clusters with auto scaling groups. Enter 'false' for clusters with no ASG and instant counts less than or equal to desired tasks"
+  type = "string"
+  default = "false"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -94,6 +94,6 @@ variable "deployment_maximum_percent" {
 
 variable "pack_and_distinct" {
   description = "Enable distinct instance and task binpacking for better cluster utilisation. Enter 'true' for clusters with auto scaling groups. Enter 'false' for clusters with no ASG and instant counts less than or equal to desired tasks"
-  type = "string"
+  type = string
   default = "false"
 }


### PR DESCRIPTION
Spreading over AZ is sensible
The distinctInstance constraint then ensures that tasks of the same
service don't end up on the same instance
Binpack then tries to ensure tasks are packed more tightly onto nodes
before spreading them out onto new empty nodes

The goal is to reduce instances in use when auto scaling groups are
controlling the number of instances.